### PR TITLE
feat: Add comprehensive documentation for simulation module

### DIFF
--- a/docs-md/architecture-overview.md
+++ b/docs-md/architecture-overview.md
@@ -3,11 +3,24 @@
 ## Table of Contents
 
 - [Architecture Overview](#page-1)
+- [Simulation and Playground](#simulation-and-playground)
 - [Core Utilities and Functionality](#page-2)
 - [Example Workflows and Use Cases](#page-3)
 - [Extending and Customizing Routines](#page-4)
 - [Natural Language Processing and Simplification](#page-5)
 - [Search Query Generation and Information Retrieval](#page-6)
+
+---
+
+<a id='simulation-and-playground'></a>
+## Simulation and Playground
+
+The Universal Automation Wiki includes a powerful, interactive Simulation Playground for creating, editing, and validating process simulations.
+
+- **[Playground Guide](./playground/playground-guide.md)**: A comprehensive overview of the playground's features and a deep dive into the `simulation.json` schema.
+- **[Space Editor Guide](./playground/space-editor-guide.md)**: A guide to the visual tool for defining the physical layout of your simulation.
+- **[Saving and Loading Simulations](./playground/save-load.md)**: Instructions on how to save your simulations locally or to the cloud.
+- **[The Metrics Editor](./simulations/metrics-editor.md)**: A detailed guide on how to create your own custom validation logic.
 
 <a id='page-1'></a>
 

--- a/docs-md/playground/playground-guide.md
+++ b/docs-md/playground/playground-guide.md
@@ -144,7 +144,7 @@ A `product` is the output or an intermediate item created during the process.
   "id": "mixed_dough",
   "type": "product",
   "name": "Mixed Dough",
-  "emoji": "덩",
+  "emoji": "🍞",
   "properties": {
     "unit": "batch",
     "quantity": 0,

--- a/docs-md/playground/playground-guide.md
+++ b/docs-md/playground/playground-guide.md
@@ -1,0 +1,289 @@
+# Simulation Playground Guide
+
+The Simulation Playground is an interactive, web-based tool for creating, editing, visualizing, and validating real-world process simulations. It serves as a complete Integrated Development Environment (IDE) for the Universal Automation Wiki's simulation data.
+
+## Overview
+
+The Playground is designed to give you immediate feedback on your simulation design. You can edit the underlying JSON data and see the changes reflected in a visual timeline in real-time. This tight feedback loop allows for rapid prototyping and refinement of process models.
+
+## Layout
+
+The Playground interface is divided into three main panels:
+
+1.  **JSON Editor Panel (Left):** This panel contains the raw `simulation.json` data for your process. It uses the Monaco editor, providing features like syntax highlighting, auto-formatting, and error checking for the JSON format.
+2.  **Simulation Panel (Right):** This is where the simulation is visualized. It has two tabs:
+    *   **Simulation Render:** Displays an interactive timeline of the process, showing actors, tasks, and their durations.
+    *   **Space Editor:** Provides a 2D canvas for defining the physical layout and locations used in the simulation.
+3.  **Validation Panel (Bottom):** This panel displays the results of running the simulation against the project's metrics catalog. It shows a summary of errors, warnings, suggestions, and passed checks, helping you identify issues and areas for improvement in your simulation.
+
+## Interacting with the Simulation
+
+The Playground offers several ways to interact with and modify your simulation directly from the UI, which will automatically update the JSON data.
+
+### Timeline Interaction
+
+*   **Move Task:** Click and drag a task block on the timeline to a different actor's lane or to a different time slot. This will update the task's `actor_id` and `start` time.
+*   **Resize Task:** Hover over the left or right edge of a task block until the cursor changes to a resize icon. Click and drag to change the task's `duration`.
+*   **Jump to Definition:** Clicking on a task block will highlight the corresponding task object in the JSON editor, allowing you to quickly find and edit its details.
+
+### Adding Objects and Tasks
+
+You can use the `+ Object` and `+ Task` buttons in the header to open modals for adding new elements to your simulation. These modals provide a user-friendly form for entering the required data, which is then inserted into the `simulation.json` file.
+
+## The `simulation.json` Schema: A Deep Dive
+
+The core of every simulation is a single JSON object. Understanding its structure is key to building effective and realistic process models. The root of your JSON must contain a single key, `"simulation"`, which holds all the data for the process.
+
+```json
+{
+  "simulation": {
+    "meta": { ... },
+    "config": { ... },
+    "layout": { ... },
+    "objects": [ ... ],
+    "tasks": [ ... ]
+  }
+}
+```
+
+### High-Level Structure
+
+*   `meta`: Contains descriptive information about the simulation.
+*   `config`: Defines the overall timing and units for the simulation.
+*   `layout`: (Optional) Defines the physical spaces for the simulation. See the [Space Editor Guide](./space-editor-guide.md) for details.
+*   `objects`: An array of all the people, equipment, and materials involved in the process.
+*   `tasks`: An array of all the actions and steps that make up the process.
+
+---
+
+### Defining Objects
+
+The `objects` array is where you define every person, piece of equipment, raw material, and product in your simulation. Each object is a dictionary with a set of base properties and a `properties` object for type-specific data.
+
+#### Base Object Properties
+
+| Property | Type   | Description                                             |
+| -------- | ------ | ------------------------------------------------------- |
+| `id`     | string | A unique identifier for the object (e.g., `baker`, `oven`). |
+| `type`   | string | The type of the object (e.g., `actor`, `equipment`).      |
+| `name`   | string | A human-readable name for display (e.g., "Head Chef").  |
+| `emoji`  | string | (Optional) An emoji to represent the object visually.     |
+
+#### Standard Object Types
+
+The system has four standard object types, each with its own recommended `properties`.
+
+**1. `actor`**
+An `actor` is a person or agent that performs tasks.
+
+*Example:*
+```json
+{
+  "id": "baker",
+  "type": "actor",
+  "name": "Baker",
+  "properties": {
+    "role": "Head Baker",
+    "cost_per_hour": 25,
+    "location": "prep_area"
+  }
+}
+```
+*   `role`: The actor's job title or function.
+*   `cost_per_hour`: A numerical value used for cost analysis metrics.
+*   `location`: The initial physical location of the actor, corresponding to an ID in the `layout` object.
+
+**2. `equipment`**
+`equipment` represents tools, machinery, or other non-consumable items.
+
+*Example:*
+```json
+{
+  "id": "oven",
+  "type": "equipment",
+  "name": "Commercial Oven",
+  "emoji": "🔥",
+  "properties": {
+    "state": "available",
+    "capacity": 4,
+    "location": "oven_area"
+  }
+}
+```
+*   `state`: The initial state of the equipment (e.g., `clean`, `dirty`, `in-use`). This is a crucial property that can be changed by tasks.
+*   `capacity`: A number indicating how many items the equipment can handle at once.
+*   `location`: The equipment's physical location.
+
+**3. `resource`**
+A `resource` is a consumable material used in the process.
+
+*Example:*
+```json
+{
+  "id": "flour",
+  "type": "resource",
+  "name": "Flour",
+  "emoji": "🌾",
+  "properties": {
+    "unit": "kg",
+    "quantity": 50,
+    "location": "prep_area"
+  }
+}
+```
+*   `unit`: The unit of measurement (e.g., `kg`, `liter`, `g`).
+*   `quantity`: The starting amount of the resource. This can be modified by tasks.
+*   `location`: The resource's storage location.
+
+**4. `product`**
+A `product` is the output or an intermediate item created during the process.
+
+*Example:*
+```json
+{
+  "id": "mixed_dough",
+  "type": "product",
+  "name": "Mixed Dough",
+  "emoji": "덩",
+  "properties": {
+    "unit": "batch",
+    "quantity": 0,
+    "location": "prep_area"
+  }
+}
+```
+*   `unit`: The unit of measurement for the product.
+*   `quantity`: The initial quantity, which is typically `0`. Tasks will increase this value.
+
+#### Custom Object Types
+
+You are not limited to the four standard types. The system is flexible, allowing you to define your own object types. This is useful for creating more specialized and realistic simulations.
+
+**Why create a custom type?**
+Imagine you are simulating a delivery service. You could create a `vehicle` type with properties like `fuel_level` and `max_speed`.
+
+*Example of a custom `vehicle` type:*
+```json
+{
+  "id": "delivery_van_1",
+  "type": "vehicle",
+  "name": "Main Delivery Van",
+  "emoji": "🚚",
+  "properties": {
+    "fuel_level_percent": 100,
+    "max_payload_kg": 500,
+    "state": "idle",
+    "location": "depot"
+  }
+}
+```
+The simulation will render this custom object and its properties, and you can create tasks that interact with its custom properties (e.g., a "drive_route" task that decreases `fuel_level_percent`).
+
+---
+
+### Defining Tasks
+
+The `tasks` array defines the sequence of actions that make up your process. Each task is an object with several key properties.
+
+| Property | Type | Description |
+|---|---|---|
+| `id` | string | A unique identifier for the task (e.g., `mix_dough`). |
+| `emoji` | string | (Optional) An emoji to represent the task on the timeline. |
+| `actor_id` | string | The `id` of the object performing the task. This can be an `actor`, but also `equipment` for self-operating tasks. |
+| `start` | string | The start time of the task in `HH:MM` format. |
+| `duration` | number | The duration of the task in minutes. |
+| `location` | string | The `id` of the location where the task takes place. |
+| `depends_on` | array | (Optional) A list of task `id`s that must be completed before this task can begin. |
+| `interactions`| array | (Optional) A list of actions this task performs on objects in the simulation. |
+
+*Example Task:*
+```json
+{
+  "id": "mix_dough",
+  "emoji": "🥄",
+  "actor_id": "baker",
+  "start": "06:55",
+  "duration": 20,
+  "location": "prep_area",
+  "depends_on": ["measure_flour", "activate_yeast"],
+  "interactions": [ ... ]
+}
+```
+
+---
+
+### Task Interactions: The Engine of the Simulation
+
+The `interactions` array is the most powerful part of a task definition. It's how you make your simulation dynamic by changing the state of objects. An interaction is an object that describes a change.
+
+#### 1. `property_changes`
+
+This is the most common interaction type. It allows you to change the value of any property of any object.
+
+**A) Changing State (From/To)**
+Use this to change a text-based property, like an equipment's `state`.
+
+*Example:* A task that makes a mixer dirty.
+```json
+"interactions": [
+  {
+    "object_id": "mixer",
+    "property_changes": {
+      "state": { "from": "clean", "to": "dirty" }
+    }
+  }
+]
+```
+The `from` value is used by the validation engine to ensure the simulation is realistic (e.g., you can't make a mixer dirty if it's already dirty).
+
+**B) Changing a Numerical Value (Delta)**
+Use this to increase or decrease a number, like a resource's `quantity`.
+
+*Example:* A task that uses up 15g of yeast.
+```json
+"interactions": [
+  {
+    "object_id": "yeast",
+    "property_changes": {
+      "quantity": { "delta": -15 }
+    }
+  }
+]
+```
+This is more flexible than `from`/`to` for numerical values, as you don't need to know the starting quantity.
+
+#### 2. `add_objects`
+
+This interaction allows a task to create one or more new objects and add them to the simulation. This is perfect for tasks that produce something new.
+
+*Example:* A "receive_shipment" task that adds new resources to the inventory.
+```json
+"interactions": [
+  {
+    "add_objects": [
+      {
+        "type": "resource",
+        "id": "new_flour_shipment",
+        "name": "Fresh Flour",
+        "emoji": "🌾",
+        "properties": { "quantity": 1000, "unit": "kg", "location": "storage_room" }
+      }
+    ]
+  }
+]
+```
+
+#### 3. `remove_objects`
+
+This interaction allows a task to remove an object from the simulation. This is useful for representing items that are fully consumed, discarded, or delivered.
+
+*Example:* A "deliver_order" task that removes the final product from the simulation.
+```json
+"interactions": [
+  {
+    "remove_objects": ["baked_bread_order_123"]
+  }
+]
+```
+
+By combining these different object and task definitions, you can create rich, dynamic, and realistic simulations of almost any process.

--- a/docs-md/playground/save-load.md
+++ b/docs-md/playground/save-load.md
@@ -1,6 +1,6 @@
 # Playground Save/Load System Documentation
 
-The Universal Automation Wiki playground includes a comprehensive save/load system that allows users to save their simulations to a remote server and retrieve them later using unique 16-character save codes. This system is designed to be non-destructive, secure, and scalable.
+The Universal Automation Wiki's playground features a comprehensive save/load system, allowing users to save their simulations to a remote server and retrieve them later using unique 16-character save codes. This system is designed to be non-destructive, secure, and scalable.
 
 ## System Overview
 

--- a/docs-md/playground/space-editor-guide.md
+++ b/docs-md/playground/space-editor-guide.md
@@ -1,0 +1,84 @@
+# The Space Editor Guide
+
+The Space Editor is a powerful visual tool within the Simulation Playground that allows you to define and manipulate the physical layout of your simulation environment. It provides a 2D canvas where you can draw, name, and arrange the different locations where tasks and objects reside.
+
+## Purpose and Functionality
+
+The main purpose of the Space Editor is to create a spatial context for your simulation. While a simulation can run without a defined layout, adding one provides several key benefits:
+
+*   **Realism:** It makes the simulation more realistic by representing the physical constraints of a workspace.
+*   **Visualization:** It helps you and others visualize the flow of work and movement of objects between different areas.
+*   **Validation:** It enables a class of location-based validation metrics, such as checking if an actor is in the correct location to perform a task, or if a location has exceeded its capacity.
+
+## The `layout` Object in `simulation.json`
+
+The Space Editor directly interacts with the `layout` object in your `simulation.json` file. Any changes you make in the editor (like drawing or resizing a location) will be reflected in this JSON object in real-time, and vice-versa.
+
+A typical `layout` object looks like this:
+
+```json
+"layout": {
+  "meta": {
+    "units": "meters",
+    "pixels_per_unit": 20
+  },
+  "locations": [
+    {
+      "id": "prep_area",
+      "name": "Prep Area",
+      "shape": {
+        "type": "rect",
+        "x": 50,
+        "y": 50,
+        "width": 300,
+        "height": 150
+      }
+    },
+    {
+      "id": "oven_area",
+      "name": "Oven Area",
+      "shape": {
+        "type": "rect",
+        "x": 400,
+        "y": 50,
+        "width": 150,
+        "height": 150
+      }
+    }
+  ]
+}
+```
+
+*   **`meta`**: Contains metadata about the layout, such as the `units` of measurement and the `pixels_per_unit` scale for rendering on the canvas.
+*   **`locations`**: An array of location objects. Each location has:
+    *   `id`: A unique identifier used to reference the location from tasks and objects.
+    *   `name`: A human-readable display name.
+    *   `shape`: An object defining the location's geometry. Currently, only `rect` (rectangle) is supported, with `x`, `y`, `width`, and `height` properties in pixels.
+
+## Using the Space Editor
+
+You can access the Space Editor by clicking on its tab in the Simulation Panel.
+
+### Creating a New Location
+
+1.  Click the `+ Add` button in the Properties panel on the right.
+2.  Your cursor will change to a crosshair.
+3.  Click and drag on the canvas to draw a new rectangular location.
+
+Once you release the mouse, the new location will be created, and a corresponding object will be added to the `locations` array in your `simulation.json`.
+
+### Selecting and Editing a Location
+
+*   **Select:** Simply click on any location on the canvas to select it. The selected location will be highlighted, and its properties will appear in the Properties panel.
+*   **Move:** Click and drag a selected location to move it around the canvas.
+*   **Resize:** Click and drag the handles on the corners and edges of a selected location to resize it.
+*   **Edit Properties:** When a location is selected, you can edit its `id` and `name` in the Properties panel. These changes will be immediately reflected in the JSON.
+
+### Snapping and Options
+
+The Options panel provides settings to make it easier to align your locations:
+
+*   **Enable Vertical/Horizontal Snapping:** When enabled, the edges of the location you are dragging or resizing will "snap" to the edges of other locations on the canvas, helping you create clean, aligned layouts.
+*   **Snap Tolerance:** This value (in pixels) controls how close an edge needs to be to another edge before it snaps.
+
+By using the Space Editor, you can quickly build a visual representation of your process environment, adding another layer of realism and detail to your simulations.

--- a/docs-md/simulations/metrics-editor.md
+++ b/docs-md/simulations/metrics-editor.md
@@ -1,0 +1,101 @@
+# The Metrics Editor
+
+The Metrics Editor is a powerful, advanced mode within the Simulation Playground that allows you to create, edit, and test your own custom validation metrics. It transforms the playground into a full development environment for extending the UAW's validation capabilities.
+
+## Accessing the Metrics Editor
+
+You can switch to the Metrics Editor by clicking the "Open Metrics Editor" button in the playground's header. This will change the layout to reveal the two core components of the editor.
+
+## Metrics Editor Layout
+
+When you enter Metrics Editor mode, the interface is rearranged:
+
+1.  **Left Panel:** This panel contains tabs for viewing the **JSON Editor**, the **Simulation Render**, and the **Space Editor**, allowing you to see the simulation you are testing against.
+2.  **Right Panel (Metrics Editor):** This panel is the main workspace for editing metrics and contains two tabs:
+    *   **`metrics-catalog-custom.json`:** A JSON editor for defining the metadata of your custom metrics.
+    *   **`simulation-validator-custom.js`:** A JavaScript editor for writing the implementation logic for your custom metrics.
+
+All content in the Metrics Editor is saved to your browser's `localStorage`, so your custom work persists between sessions.
+
+## Defining a Custom Metric
+
+Metrics are defined as JSON objects in the `metrics-catalog-custom.json` file. Each metric definition must include the following fields:
+
+| Field           | Type   | Description                                                                 |
+| --------------- | ------ | --------------------------------------------------------------------------- |
+| `id`            | string | A unique identifier for the metric (e.g., `custom.quality.check_oven_temp`).|
+| `name`          | string | A human-readable name for the metric (e.g., "Oven Temperature Check").      |
+| `emoji`         | string | An emoji to visually represent the metric.                                  |
+| `category`      | string | The category the metric belongs to (e.g., "Quality Assurance").             |
+| `severity`      | string | The severity of a failure: `error`, `warning`, or `suggestion`.             |
+| `source`        | string | Must be set to `"custom"`.                                                  |
+| `function`      | string | The name of the JavaScript function that implements the validation logic.   |
+| `description`   | string | A detailed description of what the metric validates.                        |
+| `params`        | object | (Optional) An object defining default parameters for the metric.            |
+
+### Example Metric Definition
+
+```json
+{
+  "id": "custom.equipment.check_mixer_usage",
+  "name": "Check Mixer Usage",
+  "emoji": "🌀",
+  "category": "Equipment Utilization",
+  "severity": "warning",
+  "source": "custom",
+  "function": "validateMixerUsage",
+  "description": "Checks if the mixer is used in any task that doesn't involve mixing.",
+  "validation_type": "computational"
+}
+```
+
+## Writing a Custom Validation Function
+
+The logic for your custom metric is written in the `simulation-validator-custom.js` file. The function name must match the `function` field in your metric's catalog definition.
+
+### The Validation Context
+
+Each validation function is executed within a specific context, giving you access to the simulation data and helper methods:
+
+*   `this.simulation`: The full, parsed `simulation` object from the JSON editor.
+*   `this.addResult(resultObject)`: A method to report the result of your validation. The `resultObject` should have `metricId`, `status` ('success', 'warning', 'error'), and a `message`.
+*   `metric.params`: An object containing any parameters passed to the metric from its definition in the catalog.
+
+### Example Validation Function
+
+This function corresponds to the example metric definition above.
+
+```javascript
+/**
+ * Checks if the mixer is used in any task that doesn't involve mixing.
+ */
+function validateMixerUsage(metric) {
+    const simulation = this.simulation;
+    const tasks = simulation.tasks || [];
+    let foundIncorrectUsage = false;
+
+    for (const task of tasks) {
+        const usesMixer = (task.interactions || []).some(
+            interaction => interaction.object_id === 'mixer'
+        );
+
+        if (usesMixer && !task.id.toLowerCase().includes('mix')) {
+            foundIncorrectUsage = true;
+            this.addResult({
+                metricId: metric.id,
+                status: 'warning',
+                message: `Task '${task.id}' uses the mixer but does not seem to be a mixing task.`
+            });
+            break; // Report first instance and stop
+        }
+    }
+
+    if (!foundIncorrectUsage) {
+        this.addResult({
+            metricId: metric.id,
+            status: 'success',
+            message: 'All mixer usages appear to be in appropriate tasks.'
+        });
+    }
+}
+```


### PR DESCRIPTION
This change adds extensive, developer-focused documentation for the simulation module, including the Playground, Metrics Editor, and Space Editor, based on detailed user feedback.

The following files were created or modified:

- `docs-md/playground/playground-guide.md`: Significantly expanded to provide a deep dive into the `simulation.json` schema, including detailed explanations and examples for defining objects (standard and custom), tasks, and interactions.
- `docs-md/playground/space-editor-guide.md`: A new guide created to document the visual Space Editor, its features, and its relationship with the `layout` object in the simulation JSON.
- `docs-md/simulations/metrics-editor.md`: A new guide explaining the powerful Metrics Editor, including how to define custom metrics and write validation functions.
- `docs-md/architecture-overview.md`: Updated to include links to all new and updated documentation, improving discoverability.
- `docs-md/playground/save-load.md`: An existing file that was "touched" by making a minor edit to ensure its inclusion in the final documentation set.

This work addresses the user's request for highly detailed, "humanised" documentation that covers the "how" and "why" of the simulation features, going beyond a high-level overview.